### PR TITLE
Keep dev processes alive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help:
 	@echo "Available commands:"
 	@echo "  make dev-frontend    - Starts the frontend development server (Vite)"
 	@echo "  make dev-backend     - Starts the backend development server (Uvicorn with reload)"
-	@echo "  make dev             - Starts both frontend and backend development servers"
+	@echo "  make dev             - Starts frontend and backend dev servers concurrently"
 
 dev-frontend:
 	@echo "Starting frontend development server..."
@@ -17,4 +17,6 @@ dev-backend:
 # Run frontend and backend concurrently
 dev:
 	@echo "Starting both frontend and backend development servers..."
-	@make dev-frontend & make dev-backend 
+	@make dev-frontend & \
+	make dev-backend & \
+	wait

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install
 ```bash
 make dev
 ```
-This will run the backend and frontend development servers.    Open your browser and navigate to the frontend development server URL (e.g., `http://localhost:5173/app`).
+Runs both the backend and frontend development servers concurrently and waits for them to exit. Press `Ctrl+C` to stop the servers. Open your browser and navigate to the frontend development server URL (e.g., `http://localhost:5173/app`).
 
 _Alternatively, you can run the backend and frontend development servers separately. For the backend, open a terminal in the `backend/` directory and run `langgraph dev`. The backend API will be available at `http://127.0.0.1:2024`. It will also open a browser window to the LangGraph UI. For the frontend, open a terminal in the `frontend/` directory and run `npm run dev`. The frontend will be available at `http://localhost:5173`._
 


### PR DESCRIPTION
## Summary
- update dev script to run both processes in parallel and wait
- clarify usage in the README

## Testing
- `make test` *(fails: Failed to fetch pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_684b616ebf08832380d8543b96cc79cd